### PR TITLE
Enabled link to logic

### DIFF
--- a/src/Rxnet/EventStore/EventStore.php
+++ b/src/Rxnet/EventStore/EventStore.php
@@ -376,14 +376,15 @@ class EventStore
             ->map(
                 function (PersistentSubscriptionStreamEventAppeared $eventAppeared) use ($correlationID, $group) {
                     $record = $eventAppeared->getEvent()->getEvent();
-                    //$link = $eventAppeared->getEvent()->getLink();
+                    $link = $eventAppeared->getEvent()->getLink();
                     /* @var \Rxnet\EventStore\Data\EventRecord $record */
 
                     return new AcknowledgeableEventRecord(
                         $record,
                         $correlationID,
                         $group,
-                        $this->writer
+                        $this->writer,
+                        $link
                     );
                 }
             );


### PR DESCRIPTION
Why is this disabled? Without it, linked events do not get acked.