### PR TITLE
Remove nesbot/carbon dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,6 @@
     "reactivex/rxphp": "^2.0",
     "rxnet/socket": "0.2.0",
     "voryx/event-loop": "^3.0 || ^2.0",
-    "nesbot/carbon": "^1.22",
     "zendframework/zend-stdlib": "^3.2"
   },
   "require-dev": {

--- a/src/Rxnet/EventStore/EventRecord.php
+++ b/src/Rxnet/EventStore/EventRecord.php
@@ -2,9 +2,6 @@
 
 namespace Rxnet\EventStore;
 
-
-use Carbon\Carbon;
-
 class EventRecord
 {
     protected $stream_id;
@@ -24,8 +21,7 @@ class EventRecord
         $created = $event->getCreatedEpoch();
         $date = substr($created, 0, -3);
         $micro = substr($created, -3);
-        $this->created = Carbon::createFromTimestamp($date . '.' . $micro);
-
+        $this->created = \DateTimeImmutable::createFromFormat('U.u', "{$date}.{$micro}");
 
         $this->type = $event->getEventType();
         $this->metadata = $event->getMetadata();
@@ -83,7 +79,7 @@ class EventRecord
     }
 
     /**
-     * @return \DateTime
+     * @return \DateTimeInterface
      */
     public function getCreated()
     {


### PR DESCRIPTION
The aim is to abstract from an implementation of date manipulation.
We are currently forcing the use of Carbon when we could simply use DateTime or DateTimeImmutable.
Carbon or Chronos can be used further in process manager, project, whatever using this library.

According to semver, this PR breaking compatibility, tag must be under 3.0.