### PR TITLE
Remove catch on NotMasterException

### DIFF
--- a/src/Rxnet/EventStore/EventStore.php
+++ b/src/Rxnet/EventStore/EventStore.php
@@ -370,17 +370,6 @@ class EventStore
     {
         $correlationID = $this->writer->createUUIDIfNeeded();
         return $this->connectToPersistentSubscription($streamID, $group, $parallel, $correlationID)
-            ->catch(function (\Exception $e) use ($streamID, $group, $parallel, $correlationID) {
-                if ($e instanceOf NotMasterException) {
-                    // Reconnect if not master
-                    return $this->reconnect($e->getMasterIp(), $e->getMasterPort())
-                        ->concat($this->connectToPersistentSubscription($streamID, $group, $parallel, $correlationID))
-                        ->flatMap(function () use ($streamID, $group, $parallel, $correlationID) {
-                            return $this->connectToPersistentSubscription($streamID, $group, $parallel, $correlationID);
-                        });
-                }
-                throw $e;
-            })
             ->map(
                 function (PersistentSubscriptionStreamEventAppeared $eventAppeared) use ($correlationID, $group) {
                     $record = $eventAppeared->getEvent()->getEvent();


### PR DESCRIPTION
The current implementation is bugged and must be reworked

One of the current solution to handle `NotMasterException`:

```php
        // You only need to set the default scheduler once
        Scheduler::setDefaultFactory(
            function () {
                // The getLoop method auto start loop
                return new Scheduler\EventLoopScheduler(EventLoop::getLoop());
            }
        );

        $dsn = 'tcp://admin:changeit@toto.com:1113';

        $observer = new CallbackObserver(
            function($e) {
                var_dump($e);
            }
        );

        $this->eventStore = new EventStore(EventLoop::getLoop());

        $connect = function($dsn, $stream, $group) {
            return $this->eventStore
                ->connect($dsn)
                ->flatMapTo($this->eventStore->persistentSubscription($stream, $group));
        };

        $connect($dsn, $stream, $group)
            ->catch(function (\Throwable $e) use ($connect, $dsn, $stream, $group) {
                $this->eventStore = new EventStore(EventLoop::getLoop());
                $credentials = parse_url($dsn);
                if ($e instanceof NotMasterException) {
                    $dsn = 'tcp://'.$credentials['user'].':'.$credentials['pass'].'@'.$e->getMasterIp().':'.$e->getMasterPort();
                    return $connect($dsn, $stream, $group);
                }
                throw $e;
            })
            ->flatMap($this->adapter)
            ->subscribe($observer);
```