### PR TITLE
fix "Unexpected wire type" error caused when message spans across multiple requests

### DIFF
--- a/src/Rxnet/EventStore/ReadBuffer.php
+++ b/src/Rxnet/EventStore/ReadBuffer.php
@@ -47,25 +47,23 @@ final class ReadBuffer extends Subject
             $value = $this->currentMessage . $value;
         }
 
-        do {
-            $buffer = new Buffer($value);
-            $dataLength = strlen($value);
-            $messageLength = $buffer->readInt32LE(0) + MessageConfiguration::INT_32_LENGTH;
+        $buffer = new Buffer($value);
+        $dataLength = strlen($value);
+        $messageLength = $buffer->readInt32LE(0) + MessageConfiguration::INT_32_LENGTH;
 
-            if ($dataLength == $messageLength) {
-                $socketMessages[] = $this->decomposeMessage($value);
-                $this->currentMessage = null;
-            } elseif ($dataLength > $messageLength) {
-                $message = substr($value, 0, $messageLength);
-                $socketMessages[] = $this->decomposeMessage($message);
+        if ($dataLength == $messageLength) {
+            $socketMessages[] = $this->decomposeMessage($value);
+            $this->currentMessage = null;
+        } elseif ($dataLength > $messageLength) {
+            $message = substr($value, 0, $messageLength);
+            $socketMessages[] = $this->decomposeMessage($message);
 
-                // reset data to next message
-                $value = substr($value, $messageLength, $dataLength);
-                $this->currentMessage = null;
-            } else {
-                $this->currentMessage .= $value;
-            }
-        } while ($dataLength > $messageLength);
+            // reset data to next message
+            $value = substr($value, $messageLength);
+            $this->currentMessage = $value;
+        } else {
+            $this->currentMessage = $value;
+        }
 
         //echo "messages : ".count($socketMessages) ." for ".count($this->observers)." observers \n";
         foreach ($socketMessages as $message) {


### PR DESCRIPTION
There's a couple of changes here:
- I don't think do/while loop is necessary as each packet from ES will trigger `onNext`
- in `$dataLength > $messageLength` case we've a scenario where one packet contains end of one message and beginning of another - as such `currentMessage` should become the remainder of $value
- in `else` case we already have added currentMessage to value - in case where a message spans multiple packets, this will causes following (let's assume our message spans across multiple packets and is ABCD);

1. $value = A
at the beginning $this->currentMesage is null
at the end $this->currentMessage becomes A
2. $value = B
from previous call $this->currentMessage is A
at the beginning $value becomes AB
at the end $this->currentMessage becomes AAB
3. $value = C
from previous call $this->currentMessage is AAB
at the beginning $value becomes AABC
at the end $this->currentMessage becomes AABAABC

At any point $dataLength > $messageLength condition can be encountered; it fails to decompose the message, because it was incorrectly assembled.